### PR TITLE
Add SRI hash to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You may include a script tag in your HTML and the `cashaddr` module will be defi
 <html>
   <head>
     ...
-    <script src="https://cdn.rawgit.com/bitcoincashjs/cashaddrjs/master/dist/cashaddrjs-0.2.9.min.js"></script>
+    <script src="https://cdn.rawgit.com/bitcoincashjs/cashaddrjs/master/dist/cashaddrjs-0.2.9.min.js" integrity="sha256-f0eX//RYLOSAutWPH8sPlDDqjoSKxFjMboy8Pwq+MMk=" crossorigin="anonymous"></script>
   </head>
   ...
 </html>


### PR DESCRIPTION
Resolves #6 

It should be updated each time a new version is released using `openssl dgst -sha256 -binary cashaddr.min.js  | openssl base64 -A`. It can be generated using https://srihash.org ; on the other hand, the website only supports sha384 which is currently overlong. (The specification says browsers must be compatible with sha256, 384 and 512)